### PR TITLE
 add `APP_ENV` variable to use different APIs

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,10 +14,16 @@ import { SearchPage } from "./components/SearchPage";
 import { SubjectPage } from "./components/SubjectPage";
 import GlobalStyles from "./styles/GlobalStyles";
 
+let uri: string;
+if (import.meta.env.DEV) {
+  uri = "http://localhost:8080/query";
+} else if (APP_ENV == "DEV") {
+  uri = "https://dev-api-ocwcentral.onrender.com/query";
+} else {
+  uri = "https://api-ocwcentral.onrender.com/query";
+}
 const client = new ApolloClient({
-  uri: import.meta.env.DEV
-    ? "http://localhost:8080/query"
-    : "https://api-ocwcentral.onrender.com/query",
+  uri: uri,
   cache: new InMemoryCache(),
 });
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,2 @@
 /// <reference types="vite/client" />
+declare const APP_ENV: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,4 +6,7 @@ import tsconfigPaths from "vite-tsconfig-paths";
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), svgr(), tsconfigPaths()],
+  define: {
+    APP_ENV: JSON.stringify(process.env.APP_ENV),
+  },
 });


### PR DESCRIPTION
## Related Issue

## What
- cloudflareのpreviewページでサーバーの検証用のAPIに向けるために、APP_ENVという変数を追加しました
- [cloudflare pagesの設定画面](https://dash.cloudflare.com/db517933455c7554424657069c2a61f1/pages/view/ocwcentral/settings/environment-variables)で各ブランチでの環境変数を設定しています

## 参考
https://vitejs.dev/config/shared-options.html#define

本当はviteはビルド時に --mode というオプションで環境を指定できて、env.productionとかenv.developにそれぞれ用の変数を指定できるのですが、cloudflarepagesがブランチごとに別のビルドコマンドを実行できなさそうなので、環境変数を指定するやり方でやりました。
