### PR TITLE
Re-render youtube iframe when the same transcript is clicked

### DIFF
--- a/src/components/subjectPageComponents/PlayerWrapper.tsx
+++ b/src/components/subjectPageComponents/PlayerWrapper.tsx
@@ -17,7 +17,7 @@ export const PlayerWrapper = (props: Props) => {
         height: "95%",
         maxHeight: 540,
       }}
-      src={`https://www.youtube.com/embed/${props.FocusedYoutubeId}?start=${props.startAt}&autoplay=${props.autoPlayOn}&mute=0`}
+      src={`https://www.youtube.com/embed/${props.FocusedYoutubeId}?start=${props.startAt}&autoplay=${props.autoPlayOn}&mute=0&randomNumberJustForTellingReactToReRender=${Math.random()}`}
       frameBorder="0"
       allow="fullscreen; picture-in-picture; accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope"
       key={props.FocusedYoutubeId}

--- a/src/components/subjectPageComponents/PlayerWrapper.tsx
+++ b/src/components/subjectPageComponents/PlayerWrapper.tsx
@@ -17,7 +17,10 @@ export const PlayerWrapper = (props: Props) => {
         height: "95%",
         maxHeight: 540,
       }}
-      src={`https://www.youtube.com/embed/${props.FocusedYoutubeId}?start=${props.startAt}&autoplay=${props.autoPlayOn}&mute=0&randomNumberJustForTellingReactToReRender=${Math.random()}`}
+      src={
+        `https://www.youtube.com/embed/${props.FocusedYoutubeId}?start=${props.startAt}&autoplay=${props.autoPlayOn}&mute=0` +
+        `&randomNumberJustForTellingReactToReRender=${Math.random()}`
+      }
       frameBorder="0"
       allow="fullscreen; picture-in-picture; accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope"
       key={props.FocusedYoutubeId}

--- a/src/components/subjectPageComponents/VideoTranscription.tsx
+++ b/src/components/subjectPageComponents/VideoTranscription.tsx
@@ -5,7 +5,7 @@ import { alpha } from "@mui/material/styles";
 
 type Props = {
   transcription: string;
-  setTime: (time: number) => void;
+  setTime: (time: {start: number}) => void;
   setAutoPlayOn: (autoPlayOn: number) => void;
 };
 
@@ -93,7 +93,7 @@ export function VideoTranscription(props: Props) {
               key={index}
               button
               onClick={() => {
-                props.setTime(Number(line.startTime));
+                props.setTime({start: Number(line.startTime)});
                 props.setAutoPlayOn(1);
               }}
               sx={{
@@ -123,7 +123,7 @@ export function VideoTranscription(props: Props) {
                     }}
                   >
                     {`${convertSecondToTime(
-                      Number(processedLines[index].startTime)
+                      Number(line.startTime)
                     )} `}
                   </Typography>
                 </Grid>
@@ -135,7 +135,7 @@ export function VideoTranscription(props: Props) {
                       fontSize: { xs: 16, sm: 20 },
                       pl: { md: 3.5, sm: 3, xs: 3 },
                     }}
-                  >{`${processedLines[index].text}`}</Typography>
+                  >{`${line.text}`}</Typography>
                 </Grid>
               </Grid>
             </ListItem>

--- a/src/components/subjectPageComponents/VideoTranscription.tsx
+++ b/src/components/subjectPageComponents/VideoTranscription.tsx
@@ -5,7 +5,7 @@ import { alpha } from "@mui/material/styles";
 
 type Props = {
   transcription: string;
-  setTime: (time: {start: number}) => void;
+  setTime: (time: { start: number }) => void;
   setAutoPlayOn: (autoPlayOn: number) => void;
 };
 
@@ -93,7 +93,7 @@ export function VideoTranscription(props: Props) {
               key={index}
               button
               onClick={() => {
-                props.setTime({start: Number(line.startTime)});
+                props.setTime({ start: Number(line.startTime) });
                 props.setAutoPlayOn(1);
               }}
               sx={{
@@ -122,9 +122,7 @@ export function VideoTranscription(props: Props) {
                       pt: 0.5,
                     }}
                   >
-                    {`${convertSecondToTime(
-                      Number(line.startTime)
-                    )} `}
+                    {`${convertSecondToTime(Number(line.startTime))} `}
                   </Typography>
                 </Grid>
                 <Grid item xs={11} sm={11}>

--- a/src/components/subjectPageComponents/VideoWithTranscription.tsx
+++ b/src/components/subjectPageComponents/VideoWithTranscription.tsx
@@ -24,7 +24,7 @@ const removeParenthesis = (s: string) => {
 
 export function VideoWithTranscription(props: Props) {
   const videos = props.videos ?? []; //already sorted by `ordering` field
-  const [VideoStartTime, SetVideoStartTime] = useState({start: 0});
+  const [VideoStartTime, SetVideoStartTime] = useState({ start: 0 });
   const [AutoPlayOn, SetAutoPlayOn] = useState(0);
   const [searchParams] = useSearchParams();
 

--- a/src/components/subjectPageComponents/VideoWithTranscription.tsx
+++ b/src/components/subjectPageComponents/VideoWithTranscription.tsx
@@ -24,7 +24,7 @@ const removeParenthesis = (s: string) => {
 
 export function VideoWithTranscription(props: Props) {
   const videos = props.videos ?? []; //already sorted by `ordering` field
-  const [VideoStartTime, SetVideoStartTime] = useState(0);
+  const [VideoStartTime, SetVideoStartTime] = useState({start: 0});
   const [AutoPlayOn, SetAutoPlayOn] = useState(0);
   const [searchParams] = useSearchParams();
 
@@ -110,7 +110,7 @@ export function VideoWithTranscription(props: Props) {
         )}
         <PlayerWrapper
           FocusedYoutubeId={FocusedYoutubeId}
-          startAt={VideoStartTime}
+          startAt={VideoStartTime.start}
           autoPlayOn={AutoPlayOn}
         />
       </Grid>


### PR DESCRIPTION
## Related Issue
* 同じ書き起こしのセグメントを一度クリックして、（時間が経ってから）もう一度クリックしてもそこの書き起こしの位置に動画が戻らない。
* primitive型のstateを同じ値で更新をしても再レンダリングが行われないため。

## What

- `VideoStartTime` のstateをobject型に
- そうすることで同じ書き起こしを連続でクリックしても`PlayerWrapper`に更新が伝わるが、returnされる内容が全く同じだと再レンダリングされないため、（汚い実装だが）urlに乱数を足す

## Memo
- iframeの更新のためにurlに乱数を足すアイディアはここから https://stackoverflow.com/questions/48830316/how-do-you-reload-an-iframe-with-reactjs 。回答にkey属性に乱数を指定する方法も書いてあるが、keyを変えると全体の再レンダリングが走るのか一瞬動画が消えるのが微妙だった。

<!-- レビュワーに伝えたいことがあれば -->
