### PR TITLE
display pane even when no language is properly detected on iOS

### DIFF
--- a/src/components/common/AcademicFieldsList.tsx
+++ b/src/components/common/AcademicFieldsList.tsx
@@ -122,7 +122,7 @@ export function AcademicFieldsList(props: Props) {
           </AccordionDetails>
         </Accordion>
       )}
-      {props.currentLanguage == "en" && (
+      {props.currentLanguage != "ja" && (
         <Accordion defaultExpanded={props.enFieldOpen}>
           <AccordionSummary
             expandIcon={<ExpandMoreIcon />}


### PR DESCRIPTION
## What
#181 のバグのために、言語が検知されず学問分野の一覧が表示されなかった。その場しのぎだが、検知される言語がja以外の時は英語の分野一覧を表示することにしました。