### PR TITLE
fix label for video_search_tab

### DIFF
--- a/src/components/SearchPage.tsx
+++ b/src/components/SearchPage.tsx
@@ -160,7 +160,7 @@ export function SearchPage() {
                   icon={<OndemandVideoIcon />}
                   iconPosition="start"
                   disabled
-                  label={`${t("translation.search.subject_tab")}`}
+                  label={`${t("translation.search.video_tab")}`}
                   sx={{ fontSize: 20, fontWeight: "bold" }}
                 />
               </Tabs>


### PR DESCRIPTION
## Related Issue

## What

- ビデオ検索パネルが無効化されているときに「講義動画」ではなく「科目」になってしまっている
-

## Memo

<!-- レビュワーに伝えたいことがあれば -->
