### PR TITLE
allow transcription text selection

### DIFF
--- a/src/components/subjectPageComponents/VideoTranscription.tsx
+++ b/src/components/subjectPageComponents/VideoTranscription.tsx
@@ -4,12 +4,12 @@ import {
   FormControl,
   Grid,
   List,
+  ListItemButton,
   MenuItem,
   Select,
   SelectChangeEvent,
   Typography,
 } from "@mui/material";
-import ListItem from "@mui/material/ListItem";
 import { alpha } from "@mui/material/styles";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
@@ -166,12 +166,13 @@ export function VideoTranscription(props: Props) {
       >
         {processedLines.map((line, index) => {
           return (
-            <ListItem
+            <ListItemButton
               key={index}
-              button
               onClick={() => {
-                props.setTime({ start: Number(line.startTime) });
-                props.setAutoPlayOn(1);
+                if (window.getSelection()?.toString() === "") {
+                  props.setTime({ start: Number(line.startTime) });
+                  props.setAutoPlayOn(1);
+                }
               }}
               sx={{
                 pt: 0.3,
@@ -181,6 +182,7 @@ export function VideoTranscription(props: Props) {
                   bgcolor: alpha(theme.palette.primary.main, 0.3),
                   cursor: "pointer",
                 },
+                userSelect: "text",
               }}
             >
               <Grid container direction="row">
@@ -214,7 +216,7 @@ export function VideoTranscription(props: Props) {
                   >{`${line.text}`}</Typography>
                 </Grid>
               </Grid>
-            </ListItem>
+            </ListItemButton>
           );
         })}
       </List>


### PR DESCRIPTION
## Related Issue
#118 （このissueは書き起こしのコピーボタンみたいなのをつけることを想定していると思うが、このPRはただテキストの選択ができるようにしたもの）

## What
- 書き起こしのテキストが選択できない状態だったのを、選択してコピー&ペーストができるように

## Memo
- ListItemのbuttonプロパティはdeprecatedだったので、ListItemButtonコンポーネントを使うように
- テキストの選択によってonclickが発火されるのを防ぐために、テキストの選択がされてない時のみonclickを発火するような条件分岐を追加. reference: https://stackoverflow.com/questions/31982407/prevent-onclick-event-when-selecting-text

<!-- レビュワーに伝えたいことがあれば -->
