### PR TITLE
Add missing translation in academic fields page on mobile

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,5 +78,6 @@
       "eslint --fix",
       "prettier --write"
     ]
-  }
+  },
+  "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -77,6 +77,9 @@
     "src/**/*.{ts,tsx}": [
       "eslint --fix",
       "prettier --write"
+    ],
+    "public/**/*.{json}": [
+      "prettier --write"
     ]
   },
   "license": "MIT"

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -85,6 +85,11 @@
         "english_field": "Academic Fields"
       }
     },
+    "academic_field_page": {
+      "academic_field": "Academic Fields",
+      "japanese_lecture": "Japanese lectures",
+      "english_lecture": "English lectures"
+    },
     "report": {
       "label": "Feedback",
       "message": "Thank you for your feedback. We will review your feedback and reflect it in our improvements.",

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -85,7 +85,7 @@
         "english_field": "学問分野(外国語講義)"
       }
     },
-    "academic_field_page":{
+    "academic_field_page": {
       "academic_field": "学問分野",
       "japanese_lecture": "日本語講義",
       "english_lecture": "外国語講義"

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -85,6 +85,11 @@
         "english_field": "学問分野(外国語講義)"
       }
     },
+    "academic_field_page":{
+      "academic_field": "学問分野",
+      "japanese_lecture": "日本語講義",
+      "english_lecture": "外国語講義"
+    },
     "report": {
       "label": "ご意見・不具合報告",
       "message": "ご意見ありがとうございます。ご意見を確認し、改善に反映させていただきます。",

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -13,7 +13,7 @@
     "home": {
       "message": {
         "sentence1": "OCW CentralはOCW(大学によって提供される教育資料)のポータルサイトです。",
-        "sentence2": "AIモデルによる自動書き起こしでOCWをより便利にします。",
+        "sentence2": "AIモデルによる書き起こしでOCWをより便利にします。",
         "search_button": "講義を検索"
       },
       "academic_fields": {

--- a/src/components/FieldsPage.tsx
+++ b/src/components/FieldsPage.tsx
@@ -14,6 +14,7 @@ import {
   Typography,
 } from "@mui/material";
 import { useState } from "react";
+import { useTranslation } from "react-i18next";
 import { createSearchParams, useNavigate } from "react-router-dom";
 
 type TabPanelProps = {
@@ -42,6 +43,7 @@ function separateEnglishAndJapaneseWords(word: string[]) {
 }
 /* This is only for mobile */
 export function FieldsPage() {
+  const { t } = useTranslation();
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
   const handleTabChange = (event: React.SyntheticEvent, newValue: number) => {
     setSelectedTabIndex(newValue);
@@ -76,7 +78,7 @@ export function FieldsPage() {
         align="left"
         sx={{ color: "black", pl: 2, pt: 2 }}
       >
-        <b>分野一覧</b>
+        <b>{t("translation.academic_field_page.academic_field")}</b>
       </Typography>
       <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
         <Tabs
@@ -85,8 +87,12 @@ export function FieldsPage() {
           aria-label="basic tabs example"
           variant="fullWidth"
         >
-          <Tab label="日本語講義" />
-          <Tab label="英語講義" />
+          <Tab
+            label={`${t("translation.academic_field_page.japanese_lecture")}`}
+          />
+          <Tab
+            label={`${t("translation.academic_field_page.english_lecture")}`}
+          />
         </Tabs>
       </Box>
       <TabPanel value={selectedTabIndex} index={0}>

--- a/src/components/FieldsPage.tsx
+++ b/src/components/FieldsPage.tsx
@@ -87,12 +87,8 @@ export function FieldsPage() {
           aria-label="basic tabs example"
           variant="fullWidth"
         >
-          <Tab
-            label={`${t("translation.academic_field_page.japanese_lecture")}`}
-          />
-          <Tab
-            label={`${t("translation.academic_field_page.english_lecture")}`}
-          />
+          <Tab label={t("translation.academic_field_page.japanese_lecture")} />
+          <Tab label={t("translation.academic_field_page.english_lecture")} />
         </Tabs>
       </Box>
       <TabPanel value={selectedTabIndex} index={0}>

--- a/src/components/HeaderComponents/Nav.tsx
+++ b/src/components/HeaderComponents/Nav.tsx
@@ -1,6 +1,6 @@
 import styles from "@/styles/nav.module.css";
-import MenuIcon from "@mui/icons-material/Menu";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import MenuIcon from "@mui/icons-material/Menu";
 import {
   Accordion,
   AccordionDetails,
@@ -21,16 +21,16 @@ export function Nav() {
     i18n.changeLanguage(language);
   };
   const pages = [
-    { link: "/", name: `${t("translation.header.nav.home")}` },
-    { link: "/search", name: `${t("translation.header.nav.detailed_search")}` },
-    { link: "/about", name: `${t("translation.header.nav.about")}` },
+    { link: "/", name: t("translation.header.nav.home") },
+    { link: "/search", name: t("translation.header.nav.detailed_search") },
+    { link: "/about", name: t("translation.header.nav.about") },
   ];
 
   const mobilePages = [
-    { link: "/", name: `${t("translation.header.nav.home")}` },
-    { link: "/search", name: `${t("translation.header.nav.detailed_search")}` },
-    { link: "/fields", name: `${t("translation.header.nav.academic_fields")}` },
-    { link: "/about", name: `${t("translation.header.nav.about")}` },
+    { link: "/", name: t("translation.header.nav.home") },
+    { link: "/search", name: t("translation.header.nav.detailed_search") },
+    { link: "/fields", name: t("translation.header.nav.academic_fields") },
+    { link: "/about", name: t("translation.header.nav.about") },
   ];
   const [anchorElNav, setAnchorElNav] = React.useState<null | HTMLElement>(
     null

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -127,7 +127,7 @@ const EconomicsPane = () => {
   return (
     <SubjectsRow
       subjects={data ? data.randomSubjects : []}
-      rowTitle={`${t("translation.home.academic_fields.economics")}`}
+      rowTitle={t("translation.home.academic_fields.economics")}
       loading={loading}
       error={error !== undefined}
     />
@@ -167,7 +167,7 @@ const HumanitiesPane = () => {
   return (
     <SubjectsRow
       subjects={data ? data.randomSubjects : []}
-      rowTitle={`${t("translation.home.academic_fields.humanities")}`}
+      rowTitle={t("translation.home.academic_fields.humanities")}
       loading={loading}
       error={error !== undefined}
     />
@@ -207,7 +207,7 @@ const PhysicsPane = () => {
   return (
     <SubjectsRow
       subjects={data ? data.randomSubjects : []}
-      rowTitle={`${t("translation.home.academic_fields.physics")}`}
+      rowTitle={t("translation.home.academic_fields.physics")}
       loading={loading}
       error={error !== undefined}
     />

--- a/src/components/SearchPage.tsx
+++ b/src/components/SearchPage.tsx
@@ -107,10 +107,7 @@ export function SearchPage() {
                 </Typography>
               </Grid>
               <Grid item sx={{ ml: "auto", mr: 1 }}>
-                <ReportButton
-                  url={url}
-                  name={`${t("translation.report.label")}`}
-                />
+                <ReportButton url={url} name={t("translation.report.label")} />
               </Grid>
             </Grid>
             <Grid item>
@@ -136,7 +133,7 @@ export function SearchPage() {
                 <Tab
                   icon={<OndemandVideoIcon />}
                   iconPosition="start"
-                  label={`${t("translation.search.video_tab")}`}
+                  label={t("translation.search.video_tab")}
                   sx={{ fontSize: 20, fontWeight: "bold" }}
                 />
               </Tabs>
@@ -160,7 +157,7 @@ export function SearchPage() {
                   icon={<OndemandVideoIcon />}
                   iconPosition="start"
                   disabled
-                  label={`${t("translation.search.video_tab")}`}
+                  label={t("translation.search.video_tab")}
                   sx={{ fontSize: 20, fontWeight: "bold" }}
                 />
               </Tabs>

--- a/src/components/SubjectPage.tsx
+++ b/src/components/SubjectPage.tsx
@@ -255,7 +255,7 @@ export function SubjectPage() {
           url={`${location.pathname}?video_id=${
             videos.length >= 1 ? videos[FocusedVideoOrdering].id : ""
           }`}
-          name={`${t("translation.report.label")}`}
+          name={t("translation.report.label")}
         />
       </Grid>
     </Grid>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -82,7 +82,7 @@ export function Header() {
                 <SearchIcon />
               </SearchIconWrapper>
               <StyledInputBase
-                placeholder={`${t("translation.header.search_bar")}`}
+                placeholder={t("translation.header.search_bar")}
                 inputProps={{ "aria-label": "search" }}
                 onKeyDown={(e) => {
                   onEnterDown(e);

--- a/src/components/common/ReportButton.tsx
+++ b/src/components/common/ReportButton.tsx
@@ -56,7 +56,7 @@ export function ReportButton(props: Props) {
   const [messageOpen, setMessageOpen] = useState(false);
   const handleMessageOpen = () => setMessageOpen(true);
   const handleMessageClose = () => setMessageOpen(false);
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
 
   return (
     <Box>

--- a/src/components/searchPageComponents/DetailSearchBar.tsx
+++ b/src/components/searchPageComponents/DetailSearchBar.tsx
@@ -121,7 +121,7 @@ export function DetailSearchBar() {
         </Grid>
         <Grid item xs={12} sm={12} md={4}>
           <SearchBar
-            label={`${t("translation.search.faculty_name")}`}
+            label={t("translation.search.faculty_name")}
             value={searchFaculty}
             setValue={setSearchFaculty}
             setSearchParams={setSearchParams}
@@ -151,7 +151,7 @@ export function DetailSearchBar() {
         }}
       >
         <Typography variant="h6">
-          <b>{`${t("translation.search.search")}`}</b>
+          <b>{t("translation.search.search")}</b>
         </Typography>
       </Button>
     </Box>

--- a/src/components/subjectPageComponents/VideoTranscription.tsx
+++ b/src/components/subjectPageComponents/VideoTranscription.tsx
@@ -69,9 +69,9 @@ export function VideoTranscription(props: Props) {
   // if there is only one language, don't show the language selector
   const showLanguageSelector = languages.length > 1;
   const language_map: { [key: string]: string } = {
-    original: `${t("translation.subject.original_translation")}`,
-    en: `${t("translation.subject.english_translation")}`,
-    ja: `${t("translation.subject.japanese_translation")}`,
+    original: t("translation.subject.original_translation"),
+    en: t("translation.subject.english_translation"),
+    ja: t("translation.subject.japanese_translation"),
   };
 
   return (


### PR DESCRIPTION
## Related Issue
closes #196 
## What
- モバイルページの分野一覧が翻訳されていなかったので追加しました。
