### PR TITLE
Fix typo in syllabus

### DIFF
--- a/src/components/subjectPageComponents/SubjectSyllabus.tsx
+++ b/src/components/subjectPageComponents/SubjectSyllabus.tsx
@@ -35,7 +35,7 @@ export function SubjectSyllabus({ subject }: { subject: Subject }) {
               )}
               {syllabus?.assignedGrade && (
                 <TableCell>
-                  <b>{t("translation.subject.syllabus.assighned_grade")} </b>
+                  <b>{t("translation.subject.syllabus.assigned_grade")} </b>
                 </TableCell>
               )}
               {syllabus?.courseFormat && (


### PR DESCRIPTION
## Related Issue
closes #194
## What
- シラバスの項目名にタイポがあったので修正しました。