### PR TITLE
Use R2 link for thumbnail url

### DIFF
--- a/src/components/searchPageComponents/SubjectCard.tsx
+++ b/src/components/searchPageComponents/SubjectCard.tsx
@@ -1,7 +1,7 @@
+import { SubjectOnSearchPage } from "@/gqltypes/subjectsOnSearchPage";
 import { ImageListItem, ImageListItemBar } from "@mui/material";
 import { alpha, styled } from "@mui/material/styles";
 import { Link } from "react-router-dom";
-import { SubjectOnSearchPage } from "@/gqltypes/subjectsOnSearchPage";
 
 const MyImageListItemBar = styled(ImageListItemBar)({
   color: "white",
@@ -19,7 +19,7 @@ export const SubjectCard = (subject: SubjectOnSearchPage) => {
     <Link to={`/subjects/${subject.id}`}>
       <MyImageListItem>
         <img
-          src={`${subject.thumbnailLink}`}
+          src={`${"https://storage.ocwcentral.com/" + subject.id + ".webp"}`}
           loading="lazy"
           style={{ height: 280 }}
         />

--- a/src/components/searchPageComponents/SubjectCard.tsx
+++ b/src/components/searchPageComponents/SubjectCard.tsx
@@ -19,7 +19,7 @@ export const SubjectCard = (subject: SubjectOnSearchPage) => {
     <Link to={`/subjects/${subject.id}`}>
       <MyImageListItem>
         <img
-          src={`${"https://storage.ocwcentral.com/" + subject.id + ".webp"}`}
+          src={`https://storage.ocwcentral.com/${subject.id}.webp`}
           loading="lazy"
           style={{ height: 280 }}
         />


### PR DESCRIPTION
## Related Issue
closes #188
## What
- やっとこさsubjectのサムネイルのurlをCloudflair R2のものに置き換えました。
- 画像は全てwebpに変換したため、平均で元の画像サイズの1/5に。
- キャッシュなどは設定してないですが、手元では京大から取ってくるのと遜色なくなった気がします。
<!-- レビュワーに伝えたいことがあれば -->
- 不具合等ないかの確認をお願いします。