### PR TITLE
play without muting

### DIFF
--- a/src/components/subjectPageComponents/VideoTranscription.tsx
+++ b/src/components/subjectPageComponents/VideoTranscription.tsx
@@ -75,7 +75,6 @@ type TranscriptionLineProps = {
   text: string;
   startTime: string;
   isCurrent: boolean;
-  setAutoPlayOn: (autoPlayOn: number) => void;
   playerRef: RefObject<YouTubePlayer>;
 };
 const TranscriptionLine = forwardRef<HTMLDivElement, TranscriptionLineProps>(
@@ -88,8 +87,6 @@ const TranscriptionLine = forwardRef<HTMLDivElement, TranscriptionLineProps>(
           if (window.getSelection()?.toString() === "") {
             // Playerの再生時間を変更
             props.playerRef.current?.seekTo(Number(props.startTime), "seconds");
-            // Playerの自動再生を設定
-            props.setAutoPlayOn(1);
           }
         }}
         sx={{
@@ -154,7 +151,6 @@ type VideoTranscriptionProps = {
   translations: Maybe<Translation>[];
   playedSeconds: number;
   playerRef: RefObject<YouTubePlayer>;
-  setAutoPlayOn: (autoPlayOn: number) => void;
   setPlayedSeconds: (playedSeconds: number) => void;
 };
 
@@ -299,7 +295,6 @@ export function VideoTranscription(props: VideoTranscriptionProps) {
               text={line.text}
               startTime={line.startTime}
               isCurrent={idx === nearestIdx}
-              setAutoPlayOn={props.setAutoPlayOn}
               playerRef={props.playerRef}
             />
           );

--- a/src/components/subjectPageComponents/VideoTranscription.tsx
+++ b/src/components/subjectPageComponents/VideoTranscription.tsx
@@ -89,6 +89,7 @@ const TranscriptionLine = forwardRef<HTMLDivElement, TranscriptionLineProps>(
             // Playerの再生時間を変更
             props.playerRef.current?.seekTo(Number(props.startTime), "seconds");
             // 書き起こしがクリックされるとビデオを再生する。TODO: ビデオ停止中は再生しないようにする
+            // https://github.com/ocw-central/ocw-central-frontend/issues/209
             props.setIsPlaying(true);
           }
         }}

--- a/src/components/subjectPageComponents/VideoTranscription.tsx
+++ b/src/components/subjectPageComponents/VideoTranscription.tsx
@@ -76,6 +76,7 @@ type TranscriptionLineProps = {
   startTime: string;
   isCurrent: boolean;
   playerRef: RefObject<YouTubePlayer>;
+  setIsPlaying: (isPlaying: boolean) => void;
 };
 const TranscriptionLine = forwardRef<HTMLDivElement, TranscriptionLineProps>(
   function TranscriptionLine(props, ref) {
@@ -87,6 +88,8 @@ const TranscriptionLine = forwardRef<HTMLDivElement, TranscriptionLineProps>(
           if (window.getSelection()?.toString() === "") {
             // Playerの再生時間を変更
             props.playerRef.current?.seekTo(Number(props.startTime), "seconds");
+            // 書き起こしがクリックされるとビデオを再生する。TODO: ビデオ停止中は再生しないようにする
+            props.setIsPlaying(true);
           }
         }}
         sx={{
@@ -151,6 +154,7 @@ type VideoTranscriptionProps = {
   translations: Maybe<Translation>[];
   playedSeconds: number;
   playerRef: RefObject<YouTubePlayer>;
+  setIsPlaying: (isPlaying: boolean) => void;
 };
 
 export function VideoTranscription(props: VideoTranscriptionProps) {
@@ -300,6 +304,7 @@ export function VideoTranscription(props: VideoTranscriptionProps) {
               startTime={line.startTime}
               isCurrent={idx === nearestIdx}
               playerRef={props.playerRef}
+              setIsPlaying={props.setIsPlaying}
             />
           );
         })}

--- a/src/components/subjectPageComponents/VideoTranscription.tsx
+++ b/src/components/subjectPageComponents/VideoTranscription.tsx
@@ -151,7 +151,6 @@ type VideoTranscriptionProps = {
   translations: Maybe<Translation>[];
   playedSeconds: number;
   playerRef: RefObject<YouTubePlayer>;
-  setPlayedSeconds: (playedSeconds: number) => void;
 };
 
 export function VideoTranscription(props: VideoTranscriptionProps) {

--- a/src/components/subjectPageComponents/VideoWithTranscription.tsx
+++ b/src/components/subjectPageComponents/VideoWithTranscription.tsx
@@ -26,6 +26,7 @@ const removeParenthesis = (s: string) => {
 
 export function VideoWithTranscription(props: Props) {
   const videos = props.videos ?? []; //already sorted by `ordering` field
+  const [isPlaying, setIsPlaying] = useState(false);
   const [searchParams] = useSearchParams();
   const [playedSeconds, setPlayedSeconds] = useState(0);
 
@@ -61,11 +62,13 @@ export function VideoWithTranscription(props: Props) {
           maxWidth: 960,
           maxHeight: 540,
         }}
+        onPlay={() => setIsPlaying(true)}
+        onPause={() => setIsPlaying(false)}
         onProgress={handleOnProgress}
-        playing={true}
+        playing={isPlaying}
       />
     ),
-    [FocusedYoutubeId]
+    [FocusedYoutubeId, isPlaying]
   );
   return (
     <Grid
@@ -150,7 +153,6 @@ export function VideoWithTranscription(props: Props) {
             translations={FocusedVideo.translations}
             playedSeconds={playedSeconds}
             playerRef={playerRef}
-            setPlayedSeconds={setPlayedSeconds}
           />
         </Grid>
       )}

--- a/src/components/subjectPageComponents/VideoWithTranscription.tsx
+++ b/src/components/subjectPageComponents/VideoWithTranscription.tsx
@@ -153,6 +153,7 @@ export function VideoWithTranscription(props: Props) {
             translations={FocusedVideo.translations}
             playedSeconds={playedSeconds}
             playerRef={playerRef}
+            setIsPlaying={setIsPlaying}
           />
         </Grid>
       )}

--- a/src/components/subjectPageComponents/VideoWithTranscription.tsx
+++ b/src/components/subjectPageComponents/VideoWithTranscription.tsx
@@ -26,7 +26,6 @@ const removeParenthesis = (s: string) => {
 
 export function VideoWithTranscription(props: Props) {
   const videos = props.videos ?? []; //already sorted by `ordering` field
-  const [AutoPlayOn, SetAutoPlayOn] = useState(0);
   const [searchParams] = useSearchParams();
   const [playedSeconds, setPlayedSeconds] = useState(0);
 
@@ -56,17 +55,17 @@ export function VideoWithTranscription(props: Props) {
         height="100%"
         pip={true}
         controls={true}
-        muted={true}
+        muted={false}
         style={{
           aspectRatio: "16 / 9",
           maxWidth: 960,
           maxHeight: 540,
         }}
         onProgress={handleOnProgress}
-        playing={AutoPlayOn === 1}
+        playing={true}
       />
     ),
-    [FocusedYoutubeId, AutoPlayOn]
+    [FocusedYoutubeId]
   );
   return (
     <Grid
@@ -151,7 +150,6 @@ export function VideoWithTranscription(props: Props) {
             translations={FocusedVideo.translations}
             playedSeconds={playedSeconds}
             playerRef={playerRef}
-            setAutoPlayOn={SetAutoPlayOn}
             setPlayedSeconds={setPlayedSeconds}
           />
         </Grid>


### PR DESCRIPTION
## Related Issue

## What
ReactPlayerで常にmutedなしでautoplayをonにする(muted={false}, playing={true}にする)のが良い気がしたので試してみました。
react-playerのデモ (https://cookpete.com/react-player/) がそうなってたので真似してみたものです。
以下のような挙動になります。
- PCの場合: 常に音ありでautoplayされる。
- モバイルの場合: 最初の再生だけブラウザからブロックされるのでyoutube埋め込みをクリックする必要がある。クリックすると音ありで再生される。その後飛びたい書き起こしをクリックすると、seekToメソッドで飛ぶだけなので動画は止まらずに再生される。

個人的にはミュートを自分で解除する必要があるより、こっちの動作の方が良いと思うのですが、皆さんの意見を伺えればと思います。お時間ある時に　preview URLから試していただけるとありがたいです

## Memo

<!-- レビュワーに伝えたいことがあれば -->
