### PR TITLE
Fix bugs in language selection

### DIFF
--- a/src/components/HeaderComponents/Nav.tsx
+++ b/src/components/HeaderComponents/Nav.tsx
@@ -119,7 +119,7 @@ export function Nav() {
                     fontWeight: "bold",
                   },
                   color:
-                    i18n.language === "en" ? "rgba(255,255,255,0.7)" : "white",
+                    i18n.language !== "ja" ? "rgba(255,255,255,0.7)" : "white",
                 }}
                 onClick={() => setLanguage("en")}
               >

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -6,9 +6,9 @@ import { initReactI18next } from "react-i18next";
 const options = {
   // order and from where user language should be detected
   order: [
-    "cookie",
     "navigator",
     "querystring",
+    "cookie",
     "localStorage",
     "sessionStorage",
     "htmlTag",

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -6,9 +6,9 @@ import { initReactI18next } from "react-i18next";
 const options = {
   // order and from where user language should be detected
   order: [
+    "cookie",
     "navigator",
     "querystring",
-    "cookie",
     "localStorage",
     "sessionStorage",
     "htmlTag",

--- a/src/i18n.tsx
+++ b/src/i18n.tsx
@@ -6,11 +6,11 @@ import { initReactI18next } from "react-i18next";
 const options = {
   // order and from where user language should be detected
   order: [
-    "navigator",
     "querystring",
     "cookie",
     "localStorage",
     "sessionStorage",
+    "navigator",
     "htmlTag",
     "path",
     "subdomain",


### PR DESCRIPTION
## Related Issue
closes #99
## What
- i18nにおけるlanguage detectionの優先度を修正し、言語選択後にリロードすると選択がリセットされるバグを修正。
- 日本語選択時以外は英語が選択されるようにして、どの言語も選択されないバグを修正。

## memo
動作確認をお願いします。